### PR TITLE
Fix pending bulk import retry bug

### DIFF
--- a/app/Http/Controllers/BulkImportHistoryController.php
+++ b/app/Http/Controllers/BulkImportHistoryController.php
@@ -59,6 +59,16 @@ class BulkImportHistoryController extends Controller
             return back()->withErrors(['error' => 'Only failed imports can be retried.']);
         }
 
+        // Check if there's already a pending or processing record for this file
+        $activeImport = BulkImportHistory::where('file_name', $history->file_name)
+            ->whereIn('status', [BulkImportHistory::STATUS_PENDING, BulkImportHistory::STATUS_PROCESSING])
+            ->where('id', '!=', $history->id)
+            ->first();
+
+        if ($activeImport) {
+            return back()->withErrors(['error' => 'There is already an active import for this file.']);
+        }
+
         // Reset status to pending
         $history->update([
             'status' => BulkImportHistory::STATUS_PENDING,
@@ -66,8 +76,8 @@ class BulkImportHistoryController extends Controller
             'error_message' => null,
         ]);
 
-        // Dispatch the job again
-        \App\Jobs\ProcessBooksImport::dispatch($history->file_name);
+        // Dispatch the job again with the history ID
+        \App\Jobs\ProcessBooksImport::dispatch($history->file_name, $history->id);
 
         return back()->with('status', 'Import has been queued for retry.');
     }

--- a/app/Jobs/ProcessBooksImport.php
+++ b/app/Jobs/ProcessBooksImport.php
@@ -105,7 +105,14 @@ class ProcessBooksImport implements ShouldQueue
     private function getOrCreateHistory()
     {
         if ($this->historyId) {
-            return BulkImportHistory::findOrFail($this->historyId);
+            $history = BulkImportHistory::findOrFail($this->historyId);
+            
+            // Double check that this history record is in a state that can be processed
+            if (!in_array($history->status, [BulkImportHistory::STATUS_PENDING, BulkImportHistory::STATUS_PROCESSING])) {
+                throw new \Exception("History record {$this->historyId} is not in a processable state. Current status: {$history->status}");
+            }
+            
+            return $history;
         }
 
         // Extract filename from path


### PR DESCRIPTION
Ensures bulk import retry re-processes the existing record and prevents concurrent imports for the same file.

Previously, retrying a failed import dispatched a new job without the original history ID, leading to a new history record being created and the old one remaining in 'pending' status. This change passes the history ID to the job and adds checks to prevent multiple active imports for the same file.

---
<a href="https://cursor.com/background-agent?bcId=bc-edc63091-d2d0-4045-9522-7d75d742477b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-edc63091-d2d0-4045-9522-7d75d742477b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

