### PR TITLE
Fix bulk import retry to show duplicate isbn error

### DIFF
--- a/app/Http/Controllers/BulkImportController.php
+++ b/app/Http/Controllers/BulkImportController.php
@@ -29,6 +29,7 @@ class BulkImportController extends Controller
             // Create history record
             $history = BulkImportHistory::create([
                 'file_name' => $request->file('file')->getClientOriginalName(),
+                'file_path' => $path,
                 'status' => BulkImportHistory::STATUS_PENDING,
             ]);
 

--- a/app/Http/Controllers/BulkImportHistoryController.php
+++ b/app/Http/Controllers/BulkImportHistoryController.php
@@ -66,8 +66,8 @@ class BulkImportHistoryController extends Controller
             'error_message' => null,
         ]);
 
-        // Dispatch the job again
-        \App\Jobs\ProcessBooksImport::dispatch($history->file_name);
+        // Dispatch the job again with the stored file path and history ID
+        \App\Jobs\ProcessBooksImport::dispatch($history->file_path, $history->id);
 
         return back()->with('status', 'Import has been queued for retry.');
     }

--- a/app/Models/BulkImportHistory.php
+++ b/app/Models/BulkImportHistory.php
@@ -11,6 +11,7 @@ class BulkImportHistory extends Model
 
     protected $fillable = [
         'file_name',
+        'file_path',
         'status',
         'total_records',
         'processed_records',

--- a/database/migrations/2025_01_20_120000_add_file_path_to_bulk_import_histories_table.php
+++ b/database/migrations/2025_01_20_120000_add_file_path_to_bulk_import_histories_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('bulk_import_histories', function (Blueprint $table) {
+            $table->string('file_path')->nullable()->after('file_name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('bulk_import_histories', function (Blueprint $table) {
+            $table->dropColumn('file_path');
+        });
+    }
+};


### PR DESCRIPTION
Store and use the full file path for bulk import retries to resolve 'file not found' errors and allow proper re-processing.

The original retry mechanism only passed the display `file_name`, preventing the `ProcessBooksImport` job from locating the file in storage. This change ensures the job receives the correct storage path, allowing it to re-process the file and correctly identify issues like duplicate ISBNs.

---
<a href="https://cursor.com/background-agent?bcId=bc-21c18396-0c35-425f-9c2e-640635687ad6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-21c18396-0c35-425f-9c2e-640635687ad6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

